### PR TITLE
ci: fix test timeout warnings

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -93,8 +93,8 @@ pkg_tar(
     srcs = [
         ":conf",
         ":icons.group",
-        ":package",
         ":info",
+        ":package",
     ],
     extension = "tar",
 )

--- a/unittests/info_file/BUILD.bazel
+++ b/unittests/info_file/BUILD.bazel
@@ -88,6 +88,7 @@ INFO_FILES = [
 # these unittests validate generated INFO files based ultimately on INFO_FILES array members
 [sh_test(
     name = "validate_maint_{}".format(n["suffix"]),
+    size = "small",
     srcs = [":check_{}".format(n["key"])],
     args = ["$(location :maint_{}) '{}'".format(
         n["suffix"],

--- a/unittests/resources/BUILD.bazel
+++ b/unittests/resources/BUILD.bazel
@@ -74,6 +74,7 @@ write_file(
 
 diff_test(
     name = "file_test",
+    size = "small",
     file1 = ":file",
     file2 = ":file-expected",
 )


### PR DESCRIPTION
The default size of a test is "medium" which sets an assumed timeout as well.

Unfortunately, this can trigger a warning that the declared timeout or size is too big, but "hey, I didn't declare a size!".

`bazel test //... --test_verbose_timeout_warnings` is useless, so I trimmed all tests to "small" until they complain