### PR TITLE
fix: correct file pattern for golines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,4 +44,4 @@ repos:
         name: GoLines line-limiter (runs gofmt)
         language: system
         entry: golines -w
-        files: .*\.go$
+        files: \.go$


### PR DESCRIPTION
Correcting the pattern for pre-commit makes `golines` begin to work