### PR TITLE
Fix: consistent load resource

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,7 +98,7 @@ gazelle_dependencies(
 # Toolchains
 #
 
-#load("//synology:deps.bzl", "deps")
+#load("@rules_synology//synology:deps.bzl", "deps")
 # deps()
 
 # Toolchain to bring in a binary to test packaging

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,9 +1,9 @@
 # Formats guided by https://global.download.synology.com/download/Document/Software/DeveloperGuide/Os/DSM/All/enu/DSM_Developer_Guide_7_enu.pdf
 
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("//synology:maintainer.bzl", "Maintainer", _maintainer = "maintainer")
-load("//synology:port-service-configure.bzl", _service_config = "service_config", _protocol_file="protocol_file")
-load("//synology:resource-configure.bzl", _resource_config = "resource_config")
+load("@rules_synology//synology:maintainer.bzl", "Maintainer", _maintainer = "maintainer")
+load("@rules_synology//synology:port-service-configure.bzl", _service_config = "service_config", _protocol_file="protocol_file")
+load("@rules_synology//synology:resource-configure.bzl", _resource_config = "resource_config")
 
 def INFO_file(ctx):
     # Build a manifest per some fairly predictable ordering: key:value pairs, but by wrapping as

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//synology:defs.bzl", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
+load("@rules_synology//synology:defs.bzl", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 

--- a/synology/defs.bzl
+++ b/synology/defs.bzl
@@ -1,9 +1,9 @@
 # Formats guided by https://global.download.synology.com/download/Document/Software/DeveloperGuide/Os/DSM/All/enu/DSM_Developer_Guide_7_enu.pdf
 
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("//synology:maintainer.bzl", "Maintainer", _maintainer = "maintainer")
-load("//synology:port-service-configure.bzl", _service_config = "service_config", _protocol_file="protocol_file")
-load("//synology:resource-configure.bzl", _resource_config = "resource_config")
+load("@rules_synology//synology:maintainer.bzl", "Maintainer", _maintainer = "maintainer")
+load("@rules_synology//synology:port-service-configure.bzl", _service_config = "service_config", _protocol_file="protocol_file")
+load("@rules_synology//synology:resource-configure.bzl", _resource_config = "resource_config")
 
 def INFO_file(ctx):
     # Build a manifest per some fairly predictable ordering: key:value pairs, but by wrapping as

--- a/synology/resource-configure.bzl
+++ b/synology/resource-configure.bzl
@@ -4,7 +4,7 @@
 # short-term.  If you don't have time or feel uncomfortable submitting a PR, please submit a
 # sanitized test-case so that a unittest can be built to represent what you need to be unblocked.
 
-load("//synology:port-service-configure.bzl", "PortConfigInfo")
+load("@rules_synology//synology:port-service-configure.bzl", "PortConfigInfo")
 
 def _resource_config_impl(ctx):
     resource_list = {}

--- a/unittests/BUILD.bazel
+++ b/unittests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//synology:defs.bzl", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
+load("@rules_synology//synology:defs.bzl", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
 
 # A generic maintainer to drop into other tests
 maintainer(

--- a/unittests/info-file/BUILD.bazel
+++ b/unittests/info-file/BUILD.bazel
@@ -1,0 +1,98 @@
+#load("@bazel_skylib//lib:unittest.bzl", "asserts", "analysistest")
+load("@rules_synology//synology:defs.bzl", "info_file", "maintainer")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+INFO_FILES = [
+    {
+        "suffix": "name1",
+        "key": "maintainer",
+        "value": "Roger Dodger",
+    },
+    {
+        "suffix": "name2",
+        "key": "maintainer",
+        "value": "Bart Bloggins",
+    },
+    {
+        "suffix": "name3",
+        "key": "maintainer",
+        "value": "Xart Xloggins",
+    },
+    {
+        "suffix": "url1",
+        "key": "maintainer_url",
+        "value": "Xart Xloggins",
+    },
+]
+
+# This creates copy-pasta check_{} targets where check_xx generates a shell-test script that
+# searches for a key/value "xx=..." to match a second given parameter
+[write_file(
+    name = "check_{}".format(key),
+    out = "validate_{}.sh".format(key),
+    content = [
+        "".join([
+            "VAL=$(awk -F= -vKEY=",
+            key,
+            """ '($1 == KEY) {s=$2; gsub(/^"/, "", s); gsub(/"$/, "", s); print s;}' $1) """,
+        ]),
+        'if [ "${VAL}" = "$2" ]; then',
+        '  echo "Passed"',
+        "  exit 0",
+        "else",
+        '  echo "Failed"',
+        "  exit 1",
+        "fi",
+    ],
+    is_executable = True,
+) for key in [
+    "maintainer",
+    "maintainer_url",
+]]  # TODO: gen this list from unique values of INFO_FILES[].key
+
+# These two targets would need to be hand-copy-pasta for every new key to check.  They are
+# essentially similar but change the maintainer values key to change.check.  This is a bit overkill
+# for a provider that currently has only 2 parameters, but may expand.
+#
+# maintainer_instance_name{1,2,3} have corresponding changing maintainer_name
+# maintainer_instance_url1 has corresponding change to maintainer_url
+#
+# Each is later used in an info_file(name=maint_{name1,name2,name3,url1}, ...) to generate an INFO
+# file for each change, and to check the result using a
+# sh_test(name="validate_maint_{name1,name2,name3,url1}, ...)
+
+[maintainer(
+    name = "maintainer_instance_{}".format(n["suffix"]),
+    maintainer_name = n["value"],
+    maintainer_url = "http://geocities.com/bart_bloggins",
+) for n in [i for i in INFO_FILES if i["key"] == "maintainer"]]
+
+[maintainer(
+    name = "maintainer_instance_{}".format(n["suffix"]),
+    maintainer_name = "Bart Bloggins",
+    maintainer_url = n["value"],
+) for n in [i for i in INFO_FILES if i["key"] == "maintainer_url"]]
+
+# This array of info_file(...) is used to define similar generated INFO files which are tested in
+# the sh_test(name="validate_maint_...", ) below
+[info_file(
+    name = "maint_{}".format(n["suffix"]),
+    package_name = "maint_{}".format(n["suffix"]),
+    out = "INFO_{}".format(n["suffix"]),
+    description = "test suffix: {}".format(n["suffix"]),
+    maintainer = ":maintainer_instance_{}".format(n["suffix"]),
+    os_min_ver = "10.3.2",
+    package_version = "1.2.3",
+) for n in INFO_FILES]
+
+# these unittests validate generated INFO files based ultimately on INFO_FILES array members
+[sh_test(
+    name = "validate_maint_{}".format(n["suffix"]),
+    size = "small",
+    srcs = [":check_{}".format(n["key"])],
+    args = ["$(location :maint_{}) '{}'".format(
+        n["suffix"],
+        n["value"],
+    )],
+    data = [":maint_{}".format(n["suffix"])],
+) for n in INFO_FILES]

--- a/unittests/resources/BUILD.bazel
+++ b/unittests/resources/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("//synology:defs.bzl", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
+load("@rules_synology//synology:defs.bzl", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 info_file(


### PR DESCRIPTION
Change any use of the `load()` to use `load("@rules_synology//...")` so that anyone re-using these functions can use the examples and reuse the packages directly rather than guess the more global version of the import statement.