### PR TITLE
ci: cleanup code in examples too

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,15 @@ repos:
         language: system
         entry: bazel run //tools:gazelle
         # the "identify" needs to be updated to recognize bazel files directly
-        files: .*\.bazel$ .*\.bzl$ WORKSPACE$
+        files: '\.bazel$|\.bzl$|WORKSPACE'
+      - id: buildifier-examples
+        name: bazel run //tools:gazelle in examples
+        description: Cleans up BUILD files as confirmed in starlark linter
+        language: system
+        entry: bash tools/gazelle-examples.sh
+        # the "identify" needs to be updated to recognize bazel files directly
+        files: '\.bazel$|\.bzl$|WORKSPACE'
+        require_serial: true
       - id: golines
         name: GoLines line-limiter (runs gofmt)
         language: system

--- a/examples/example-server/spk/exampleserver/BUILD.bazel
+++ b/examples/example-server/spk/exampleserver/BUILD.bazel
@@ -57,13 +57,25 @@ pkg_tar(
     package_dir = "/usr/bin",
 )
 
-SCRIPTS = [ "preinst", "postinst", "preuninst", "postuninst", "preupgrade", "postupgrade", "start-stop-status" ]
-[ copy_file(name = "stub_{}".format(f), src="@rules_synology//synology:stub_script", out=f) for f in SCRIPTS ]
+SCRIPTS = [
+    "preinst",
+    "postinst",
+    "preuninst",
+    "postuninst",
+    "preupgrade",
+    "postupgrade",
+    "start-stop-status",
+]
 
+[copy_file(
+    name = "stub_{}".format(f),
+    src = "@rules_synology//synology:stub_script",
+    out = f,
+) for f in SCRIPTS]
 
 pkg_files(
     name = "scripts",
-    srcs = [ ":stub_{}".format(f) for f in SCRIPTS ],
+    srcs = [":stub_{}".format(f) for f in SCRIPTS],
     attributes = pkg_attributes(
         mode = "0755",
     ),

--- a/examples/example-server/tests/BUILD.bazel
+++ b/examples/example-server/tests/BUILD.bazel
@@ -1,12 +1,15 @@
 load("@rules_pkg//pkg:verify_archive.bzl", "verify_archive_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
-copy_file (name="spk", src = "//spk/exampleserver:spk", out="spk.tar")
+copy_file(
+    name = "spk",
+    src = "//spk/exampleserver:spk",
+    out = "spk.tar",
+)
 
 verify_archive_test(
     name = "spk_contains_required_scripts",
-    target = ":spk",
-    max_size=25,
+    max_size = 25,
     must_contain = [
         "INFO",
         "PACKAGE_ICON_120.PNG",
@@ -18,10 +21,8 @@ verify_archive_test(
         "PACKAGE_ICON_64.PNG",
         "PACKAGE_ICON_72.PNG",
         "PACKAGE_ICON_90.PNG",
-
         "conf/resource",
         "package.tgz",
-
         "scripts/postinst",
         "scripts/postuninst",
         "scripts/postupgrade",
@@ -30,6 +31,5 @@ verify_archive_test(
         "scripts/preupgrade",
         "scripts/start-stop-status",
     ],
+    target = ":spk",
 )
-
-

--- a/tools/gazelle-examples.sh
+++ b/tools/gazelle-examples.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for d in $(find examples -name WORKSPACE -exec dirname {} \; ); do \
+    (cd ${d} && bazel run //:gazelle) ; \
+done


### PR DESCRIPTION
PR to activate gazelle-based opinionated formatting in examples dirs too (which are otherwise skipped due to `.bazelignore`)