### PR TITLE
chore: build recommendation: sha256

### DIFF
--- a/examples/example-server/WORKSPACE
+++ b/examples/example-server/WORKSPACE
@@ -4,6 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 http_archive(
     name = "rules_proto_grpc",
     strip_prefix = "rules_proto_grpc-4.4.0",
+    sha256 = "928e4205f701b7798ce32f3d2171c1918b363e9a600390a25c876f075f1efc0a",
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/4.4.0/rules_proto_grpc-4.4.0.tar.gz"],
 )
 


### PR DESCRIPTION
During the build, the example gets a build recommendation to add a sha256; this PR just puts that there to cut the logspam.