### PR TITLE
doc: commit dockcross layer for reference

### DIFF
--- a/tools/dockcross-linux-x86-bazel/Dockerfile
+++ b/tools/dockcross-linux-x86-bazel/Dockerfile
@@ -1,0 +1,5 @@
+FROM dockcross/linux-x86
+
+RUN mkdir -p /usr/bin && curl -Lo /usr/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-amd64 && chmod +x /usr/bin/bazel
+RUN echo 'build --platforms=@rules_synology//models:ds1819+  --incompatible_enable_cc_toolchain_resolution --toolchain_resolution_debug=.*' > ~root/.bazelrc
+# --experimental_enable_docker_sandbox --spawn_strategy=docker,sandboxed


### PR DESCRIPTION
For reference, I've added a Dockerfile to express as simply as possible how I've been testing an execution_platform, unsuccessfully.
 - basic dockcross x86-64
 - fetch and layer on bazelisk as bazel
 - feed some ds1819+ cross-compile settings to bazelrc to reduce toil for my test environment

## Usage

I'm currently using this as:
```
docker build -t test-x86 - < tools/dockcross-linux-x86-bazel/Dockerfile
docker run --rm -it -v $(pwd):/rules_synology -w /rules_synology/examples/cross-helloworld test-x86:latest /bin/bash
bazel build //...
```

This may change; the canonical reference is in `examples/cross-helloworld/README.md`