### PR TITLE
chore: pin bazel version to avoid breaking changes in bazel-7.0.0

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,0 +1,2 @@
+6.3.2
+# https://github.com/bazelbuild/bazel/issues/17289 : default enable_bzlmod empty MODULES.bazel caused split-brain in dependencies

--- a/examples/example-server/.bazelversion
+++ b/examples/example-server/.bazelversion
@@ -1,0 +1,2 @@
+6.4.0
+# https://github.com/bazelbuild/bazel/issues/17289 : default enable_bzlmod empty MODULES.bazel caused split-brain in dependencies


### PR DESCRIPTION
The `bazel-7.0.0` behaviour of the `--enable_bzlmod` by default activates a split-brain issue noted a year ago in bzlmod dependency resolution.  Pinning the version sub-7.0.0 where C++ toolchains are resolved allows us to delay the forced-upgrade.
 
As noted in https://github.com/bazelbuild/bazel/issues/17289, when `--enable_bzlmod` is active, the dependencies resolved in `WORKSPACE` are ignored in `MODULES.bazel`, including the magic/implicit `platforms`... so the `platforms` resolution works for `WORKSPACE` but not in the bzlmod case: `@platforms` is `@@platforms` in the `WORKSPACE` case, but `@platforms` is `@@platforms~0.0.5` surfacing a default due to `MODULES.bazel` being empty.  This causes a mismatch in defined toolchains and resolved toolchains.

https://github.com/bazelbuild/bazel/issues/17289#issuecomment-1438406403 describes it better.

What I see is that the `@@platforms` defines the functions and things we need, but the pass-thru-default `@@platforms~0.0.5` doesn't.

"works as designed" apparently, so this is intended breakage.