### PR TITLE
chore: cleaner ignore files for cleaner commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ bazel-*
 
 # examples dirs
 examples/*/bazel-*
+
+# ignore cruft from bazel-7.0.0 default MODULE file(s) until we can upgrade to 7.0.0
+examples/*/MODULE.bazel*


### PR DESCRIPTION
ignore some more `bazel-7.0.0` cruft until we can complete the forced upgrade