### PR TITLE
feat: expand basic server example

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -5,6 +5,7 @@ load("@rules_synology//synology:images.bzl", _images = "images")
 load("@rules_synology//synology:info-file.bzl", _info_file = "info_file")
 load("@rules_synology//synology:maintainer.bzl", "Maintainer", _maintainer = "maintainer")
 load("@rules_synology//synology:port-service-configure.bzl", _protocol_file = "protocol_file", _service_config = "service_config")
+load("@rules_synology//synology:privilege-configure.bzl", _privilege_config = "privilege_config")
 load("@rules_synology//synology:resource-configure.bzl", _resource_config = "resource_config")
 
 SPK_REQUIRED_SCRIPTS = ["preinst", "postinst", "preuninst", "postuninst", "preupgrade", "postupgrade"]
@@ -14,6 +15,7 @@ SPK_REQUIRED_SCRIPTS = ["preinst", "postinst", "preuninst", "postuninst", "preup
 images = _images
 info_file = _info_file
 maintainer = _maintainer
+privilege_config = _privilege_config
 protocol_file = _protocol_file
 resource_config = _resource_config
 service_config = _service_config

--- a/examples/example-server/WORKSPACE
+++ b/examples/example-server/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "example-server")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 

--- a/examples/example-server/bazel-example-server
+++ b/examples/example-server/bazel-example-server
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_allanc/f64251ef138774cf532dce15d7ea1cc7/execroot/__main__

--- a/examples/example-server/spk/exampleserver/BUILD.bazel
+++ b/examples/example-server/spk/exampleserver/BUILD.bazel
@@ -1,14 +1,15 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@rules_synology//:defs.bzl", "SPK_REQUIRED_SCRIPTS", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
+load("@rules_synology//:defs.bzl", "SPK_REQUIRED_SCRIPTS", "images", "info_file", "maintainer", "privilege_config", "protocol_file", "resource_config", "service_config")
 
 info_file(
     name = "info",
     package_name = "exampleserver",
+    arch_strings = ["denverton"],
     description = "A basic example of a TCP service running on a static port",
     maintainer = "//maintainers:chickenandpork",
-    os_min_ver = "7.0",
+    os_min_ver = "7.0-1",  # correct-format=[^\d+(\.\d+){1,2}(-\d+){1,2}$]
     package_version = "1.0.0-1",
 )
 
@@ -25,6 +26,10 @@ protocol_file(
     service_config = [":exampleserver-main"],
 )
 
+privilege_config(
+    name = "priv",
+)
+
 resource_config(
     name = "rez",
     resources = [":protocol"],
@@ -39,6 +44,7 @@ images(
 pkg_files(
     name = "conf",
     srcs = [
+        ":priv",
         ":rez",
     ],
     attributes = pkg_attributes(
@@ -50,6 +56,16 @@ pkg_files(
 
 pkg_tar(
     name = "package",
+    srcs = [
+        ":protocol",
+    ],
+    extension = "tgz",
+    package_dir = "/",
+    deps = [":package-bin"],
+)
+
+pkg_tar(
+    name = "package-bin",
     srcs = [
         "//server",
     ],

--- a/synology/info-file.bzl
+++ b/synology/info-file.bzl
@@ -39,6 +39,7 @@ def info_file_impl(ctx):
         'description="{}"'.format(ctx.attr.description),
         'maintainer="{}"'.format(ctx.attr.maintainer[Maintainer].name),
         'arch="{}"'.format(" ".join(ctx.attr.arch_strings)),
+        'thirdparty="yes"',
     ]
 
     # optional bits

--- a/synology/privilege-configure.bzl
+++ b/synology/privilege-configure.bzl
@@ -1,0 +1,48 @@
+# This set of functions allows generation of a conf/privilege file.
+#
+# Some functions may not be available at first release; I'm sorry if that blocks you in the
+# short-term.  If you don't have time or feel uncomfortable submitting a PR, please submit a
+# sanitized test-case so that a unittest can be built to represent what you need to be unblocked.
+#
+# See https://help.synology.com/developer-guide/privilege/privilege_config.html
+
+#load("@rules_synology//synology:port-service-configure.bzl", "PortConfigInfo")
+
+def _privilege_config_impl(ctx):
+    privilege_list = {
+        "defaults": {
+            "run-as": "package",  # ( package | root )
+        }
+    }
+
+    if ctx.outputs.out:
+        outfile = ctx.outputs.out
+    else:
+        outfile = ctx.actions.declare_file("privilege")
+
+    # appending "" element and joining results in a finishing blank line which has no effect on JSON
+    # parsers but gives a blank line at end which is easier to `cat` the results when manually
+    # checking.  This might be easier as a simple append, but I had some syntax issues, and this
+    # worked.
+    ctx.actions.write(
+        outfile,
+        "\n".join([
+            json.encode_indent(privilege_list, indent = "  "),
+            "",
+        ]),
+    )
+
+    return [
+        DefaultInfo(
+            files = depset(direct = [outfile]),
+            runfiles = ctx.runfiles(files = [outfile]),
+        ),
+    ]
+
+privilege_config = rule(
+    doc = "A function (currently stubbed) to define a privilege configuration (conf/privilege) configuring packages installed in Synology.",
+    implementation = _privilege_config_impl,
+    attrs = {
+        "out": attr.output(mandatory = False),
+    },
+)


### PR DESCRIPTION
Expand the basic packaged server with a functionally installable payload; start/stop/status, pre/post install not yet checked.  There's likely a good deal of pre-build sanity-check needed as well, all in due time.