### PR TITLE
chore: update precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 ---
 repos:
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.26.1
+    rev: v1.33.0
     hooks:
       - id: yamllint
         args: [
@@ -17,7 +17,7 @@ repos:
           '{extends: relaxed, rules: {line-length: {max: 120}}}'
         ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: no-commit-to-branch
       - id: trailing-whitespace
@@ -27,12 +27,12 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.18.3
+    rev: 0.27.3
     hooks:
       - id: check-github-workflows
       - id: check-renovate
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v6.2.0
+    rev: v8.3.0
     hooks:
       - id: cspell
         # a local allowlist of dictionary words in .github/cspell.yaml.  This can get comical --


### PR DESCRIPTION
routine update to pre-commit -- of note, the YAMLLINT should actually work again without a bad dependency line bombing out on the setup.py:
```
              raise InvalidSpecifier(f"Invalid specifier: '{spec}'")
          setuptools.extern.packaging.specifiers.InvalidSpecifier: Invalid specifier: '>=3.5.*'
          [end of output]
```