### PR TITLE
fix: Automerge is too eager, needs to wait for check_suite to succeed

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,29 +1,23 @@
 name: automerge
+
+# https://github.com/ridedott/merge-me-action/discussions/997#discussioncomment-3166077
+# yamllint disable-line rule:truthy
 on:
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
-  pull_request_review:
-    types:
-      - submitted
   check_suite:
-    types:
-      - completed
-  status: {}
+    conclusion: success
+    # status: {}  # check_events only listenable in main/master branch in github app
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    permissions: write-all
+    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+    # permissions: write-all
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
       ## actions: read|write|none
-      ##checks: write
-      #contents: write
+      # checks: write
+      # contents: write
     steps:
       - id: automerge
         name: automerge

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
           '-d',
           '{extends: relaxed, rules: {line-length: {max: 120}}}'
         ]
+        files: .*\.(yml|yaml)$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:


### PR DESCRIPTION
Delaying the auto merge check should encourage it to only merge PRs that have passed the checks successfully.