### PR TITLE
chore: buildifier to cleanup format

### DIFF
--- a/dsm/BUILD.bazel
+++ b/dsm/BUILD.bazel
@@ -8,5 +8,4 @@ constraint_setting(
     name = v,
     constraint_setting = ":dsm_rel_majmin",
     visibility = ["//visibility:public"],
-) for v in dsm_range ]
-
+) for v in dsm_range]

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 alias(
     name = "buildifier",
@@ -22,7 +22,7 @@ go_library(
         "main.go",
         "resize.go",
     ],
-    importpath = "github.com/chickenandpork/bazelspk/tools",
+    importpath = "github.com/chickenandpork/rules_synology/tools",
     visibility = ["//visibility:private"],
     deps = ["@com_github_disintegration_imaging//:imaging"],
 )

--- a/unittests/info-file/BUILD.bazel
+++ b/unittests/info-file/BUILD.bazel
@@ -1,6 +1,7 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
 #load("@bazel_skylib//lib:unittest.bzl", "asserts", "analysistest")
 load("@rules_synology//:defs.bzl", "info_file", "maintainer")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 INFO_FILES = [
     {

--- a/unittests/resources/BUILD.bazel
+++ b/unittests/resources/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("@rules_synology//:defs.bzl", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_synology//:defs.bzl", "images", "info_file", "maintainer", "protocol_file", "resource_config", "service_config")
 
 info_file(
     name = "info",


### PR DESCRIPTION
Some poor formatting snuck into master branch. Let's kill it with a basic `buildifier`:

`bazel run //tools:buildifier`