### PR TITLE
chore(deps): update netfilter-kmods to v1.1.0 to get kernel config

### DIFF
--- a/examples/example-kernelmod-spk/WORKSPACE
+++ b/examples/example-kernelmod-spk/WORKSPACE
@@ -62,10 +62,10 @@ http_file(
 
 http_archive(
     name = "prebuilt_denverton_kmods",
-    build_file_content = """filegroup(name="mods", srcs = glob(["net/**"]), visibility = ["//visibility:public"])""",
-    sha256 = "cae47a9e2be6bf30f674315ac4153666bb5f488fc10de86cd3fe4336f2aab113",
+    build_file_content = """filegroup(name="mods", srcs = [".config"]+glob(["net/**"]), visibility = ["//visibility:public"])""",
+    sha256 = "d620c87afca2ee79ff13bc21e9b0b4e6ed2f942be362478ef7304c46fdbecb49",
     urls = [
-        "https://github.com/chickenandpork/synology-kmods-netfilter-iptables/releases/download/v1.0.0/denverton-7.2.txz"
+        "https://github.com/chickenandpork/synology-kmods-netfilter-iptables/releases/download/v1.1.0/denverton-7.2.txz"
     ],
 )
 


### PR DESCRIPTION
https://github.com/chickenandpork/synology-kmods-netfilter-iptables/releases/tag/v1.1.0 offered the kernel config used to create the modules in the package.  We herein update the dependency version so that we can take advantage of the kernel config in an example build.