### PR TITLE
chore: format/lint

### DIFF
--- a/examples/example-server/server/health.go
+++ b/examples/example-server/server/health.go
@@ -19,10 +19,11 @@ type gRPCHealthServer struct {
 // down
 //
 // This can be used with
-//  health.RegisterHealthcheckServer(
-//      gRPCServer,  // grpc.NewServer(...)
-//	newGRPCHealthServer(aLogger, requestedShutdown),
-//  )
+//
+//	 health.RegisterHealthcheckServer(
+//	     gRPCServer,  // grpc.NewServer(...)
+//		newGRPCHealthServer(aLogger, requestedShutdown),
+//	 )
 func newGRPCHealthServer(l *zap.SugaredLogger, requestedShutdown *atomic.Bool) health.HealthServer {
 	return &gRPCHealthServer{
 		logger:            l,


### PR DESCRIPTION
Basic scripted reformat to reduce whitespace churn