### PR TITLE
feat: script to confirm crosstool selection

### DIFF
--- a/tools/confirm-cross-selection.bash
+++ b/tools/confirm-cross-selection.bash
@@ -1,0 +1,13 @@
+#!bash
+
+TOOLS=$(dirname $(readlink -f $0))
+TMPFILE=$(mktemp -t check)
+trap "rm -f ${TMPFILE}" EXIT
+
+docker build -t test-x86 - < ${TOOLS}/dockcross-linux-x86-bazel/Dockerfile
+
+docker run --rm -it -v $(dirname ${TOOLS}):/rules_synology -w /rules_synology/examples/cross-helloworld test-x86:latest /usr/bin/bazel build --platforms=@rules_synology//models:ds1819+  --incompatible_enable_cc_toolchain_resolution --toolchain_resolution_debug=.* //... 2>&1 | tee ${TMPFILE}/cross-stderr
+
+grep denverton-gcc850_glibc226_x86_64-GPL//:cc_toolchain ${TMPFILE}/cross-stderr >/dev/null 2>&1 || { echo "denvertoon toolchain not considered"; exit 1; }
+
+exit 0


### PR DESCRIPTION
During bzlmodification, I was unsure that the proper cross toolchain was considered and used.

This script sifts the output and confirms that the desired toolchain is chosen when it should be.