### PR TITLE
chore: cleanup repo_names

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,11 +3,11 @@ module(
     version = "0.1.0",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.7.1", repo_name = "bazel_skylib")
-bazel_dep(name = "gazelle", version = "0.38.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "gazelle", version = "0.38.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_go", version = "0.50.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.50.0")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_shellcheck", version = "0.3.3", repo_name = "com_github_aignas_rules_shellcheck")
 
@@ -21,12 +21,12 @@ http_file(
     ],
 )
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
 #Download toolchain for this version for both host and some platform targets (maybe the right ones)
 go_sdk.download(version = "1.22.4")
 
-go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 
 # Include *direct* Go dependencies

--- a/bzl/go_dependencies.bzl
+++ b/bzl/go_dependencies.bzl
@@ -1,4 +1,4 @@
-load("@bazel_gazelle//:deps.bzl", "go_repository")
+load("@gazelle//:deps.bzl", "go_repository")
 
 def go_dependencies():
     go_repository(

--- a/examples/cross-helloworld/BUILD.bazel
+++ b/examples/cross-helloworld/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template_rule")
-load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@gazelle//:def.bzl", "gazelle")
 
 cc_binary(
     name = "main",

--- a/examples/cross-helloworld/MODULE.bazel
+++ b/examples/cross-helloworld/MODULE.bazel
@@ -14,15 +14,15 @@ archive_override(module_name = "rules_python",
 
 bazel_dep(name = "rules_synology")
 bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
-bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "gazelle", version = "0.34.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.42.0")
+bazel_dep(name = "gazelle", version = "0.34.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 
 # When reusing for your own project, don't use this local-override
 local_path_override(module_name = "rules_synology", path = "../..")
 
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
 #Download toolchain for this version for both host and some platform targets (maybe the right ones)
 go_sdk.download(version = "1.20.5")

--- a/examples/example-kernelmod-spk/MODULE.bazel
+++ b/examples/example-kernelmod-spk/MODULE.bazel
@@ -2,9 +2,9 @@ module(name = "examples_example-kernel-mod", version = "1.0")
 
 bazel_dep(name = "rules_synology")
 bazel_dep(name = "gazelle", version = "0.34.0")
-bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.42.0")
 bazel_dep(name = "rules_pkg", version="0.9.1")
-bazel_dep(name = "rules_python", version="0.35.0")
+bazel_dep(name = "rules_python", version="0.35.0")  # can remain implicit in most builds
 
 # When reusing for your own project, don't use this local-override
 local_path_override(module_name = "rules_synology", path = "../..")
@@ -31,6 +31,7 @@ http_archive(
 )
 
 # ignore user==root in python builds -- should not be necessary in most build situations
+# https://github.com/bazelbuild/rules_python/pull/713#issuecomment-1885628496
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     configure_coverage_tool = False,
@@ -38,7 +39,7 @@ python.toolchain(
     python_version = "3.11",
 )
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
 #Download toolchain for this version for both host and some platform targets (maybe the right ones)
 go_sdk.download(version = "1.22.4")

--- a/examples/example-kernelmod-spk/bzl/go_dependencies.bzl
+++ b/examples/example-kernelmod-spk/bzl/go_dependencies.bzl
@@ -1,4 +1,4 @@
-load("@bazel_gazelle//:deps.bzl", "go_repository")
+load("@gazelle//:deps.bzl", "go_repository")
 
 def go_dependencies():
     go_repository(

--- a/examples/example-server/MODULE.bazel
+++ b/examples/example-server/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "rules_synology")
 
 #bazel_dep(name = "aspect_bazel_lib", version = "2.8.1")
 bazel_dep(name = "gazelle", version = "0.34.0")
-bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.42.0")
 bazel_dep(name = "rules_pkg", version = "0.9.1")
 bazel_dep(name = "rules_proto_grpc", version = "5.0.0")
 bazel_dep(name = "rules_proto_grpc_go", version = "5.0.0")
@@ -28,7 +28,7 @@ local_path_override(
     path = "../..",
 )
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
 #Download toolchain for this version for both host and some platform targets (maybe the right ones)
 go_sdk.download(version = "1.22.4")

--- a/examples/example-server/api/BUILD.bazel
+++ b/examples/example-server/api/BUILD.bazel
@@ -1,13 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-
-go_library(
-    name = "api",
-    embed = [":helloworld_go_proto"],
-    importpath = "github.com/chickenandpork/rules_synology/examples/example-server/api",
-    visibility = ["//visibility:public"],
-)
 
 proto_library(
     name = "helloworld_proto",
@@ -17,7 +9,7 @@ proto_library(
 
 go_proto_library(
     name = "helloworld_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@rules_go//proto:go_grpc"],
     importpath = "github.com/chickenandpork/rules_synology/examples/example-server/api",
     proto = ":helloworld_proto",
     visibility = ["//visibility:public"],

--- a/examples/example-server/bzl/go_dependencies.bzl
+++ b/examples/example-server/bzl/go_dependencies.bzl
@@ -1,4 +1,4 @@
-load("@bazel_gazelle//:deps.bzl", "go_repository")
+load("@gazelle//:deps.bzl", "go_repository")
 
 def go_dependencies():
     go_repository(

--- a/examples/example-server/go.mod
+++ b/examples/example-server/go.mod
@@ -9,15 +9,15 @@ require (
 	github.com/grpc-ecosystem/grpc-health-probe v0.4.31 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.3.0 // indirect
 	github.com/zeebo/errs v1.3.0 // indirect
-	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
+	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.24.0 // indirect
-	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/net v0.26.0
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240617180043-68d350f18fd4 // indirect
-	google.golang.org/grpc v1.65.0 // indirect
+	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2 // indirect
 )

--- a/examples/example-server/server/BUILD.bazel
+++ b/examples/example-server/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_binary(
     name = "server",
@@ -15,7 +15,7 @@ go_library(
     importpath = "github.com/chickenandpork/rules_synology/examples/example-server/server",
     visibility = ["//visibility:private"],
     deps = [
-        "//api",
+        "//api:helloworld_go_proto",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//health/grpc_health_v1",
         "@org_golang_google_grpc//reflection",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@gazelle//:def.bzl", "gazelle")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 
 alias(
     name = "buildifier",


### PR DESCRIPTION
Replace `repo_name` overrides with their bzlmod name