### PR TITLE
feat: release to BCR

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://chickenandpork.github.io/rules_synology/",
+  "maintainers": [
+    {
+      "name": "Allan Clark",
+      "email": "allanc@chickenandpork.com",
+      "github": "chickenandpork"
+    }
+  ],
+  "repository": [
+    "github:chickenandpork/rules_synology"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,14 @@
+# We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
+# For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
+bcr_test_module:
+  module_path: "examples/cross-helloworld-no-go"
+  matrix:
+    platform: ["ubuntu2204", "ubuntu2404"]
+    bazel: [7.x]
+  tasks:
+    test_linux:
+      name: "Run linux crosstool tests"
+      bazel: ${{ bazel }}
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}

--- a/.github/cspell.yaml
+++ b/.github/cspell.yaml
@@ -23,7 +23,9 @@ words:
   - bazelspk
   - buildifier
   - bzlmod
+  - bzlmodify
   - ibazel
+  - rulesets
   # Vanity
   - allanc
   - chickenandpork
@@ -34,6 +36,7 @@ words:
   - ThirdParty
   - RobertRoss
   # Actual useful words
+  - Automerge
   - BUILDNUM
   - buildable
   - configfile
@@ -41,6 +44,7 @@ words:
   - crosstool
   - dockcross
   - helloworld
+  - golines
   - kernelmod
   - maint
   - mkdocs
@@ -51,3 +55,4 @@ words:
   - softlinks
   - subdir
   - subdirs
+  - varargs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
         id: release
         with:
           release-type: simple
+          include-v-in-tag: false
       -
         name: Clone Repo
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
This PR configures [Publish-to-BCR](https://github.com/settings/installations/55499801) to mirror releases to the Bazel Central Registry for easier re-use by others.