### PR TITLE
fix: correct image names for presubmit phase in BCR

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,7 +3,7 @@
 bcr_test_module:
   module_path: "examples/cross-helloworld-no-go"
   matrix:
-    platform: ["ubuntu2204", "ubuntu2404"]
+    platform: ["ubuntu2004", "ubuntu2204"]
     bazel: [7.x]
   tasks:
     test_linux:


### PR DESCRIPTION
[Error in PR 2913](https://buildkite.com/bazel/bcr-presubmit/builds/8060#01926684-68cb-48ff-a00b-3738fb7e61d8) in bazelbuild/bazel-central-registry#2913 was due to an overly eager copy of `ubuntu2404` which isn't yet available in [GCR.io BCR registry](gcr.io/bazel-public/ubuntu2204) so it fails of course.

Back-stepping two versions should fix it.