### PR TITLE
fix: upload additional archive for BCR; optimize for size

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,19 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4
       -
+        name: Cut Size-Optimized Archive
+        env:
+          TAG: ${{ steps.release.outputs.tag_name }}
+          PREFIX: rules_synology-${{ steps.release.outputs.tag_name }}
+        if: ${{ steps.release.outputs.release_created }}
+        run: git archive --format=tar --prefix=${PREFIX}/ ${TAG} | xz -c9 ${PREFIX}.tar.xz
+      -
+        name: Upload Size-Optimized Archive
+        env:
+          TAG: ${{ steps.release.outputs.tag_name }}
+          PREFIX: rules_synology-${{ steps.release.outputs.tag_name }}
+        run: gh release upload ${TAG} ${PREFIX}.tar.xz
+      -
         name: Collate Docs
         if: ${{ steps.release.outputs.release_created }}
         run: bazel run //docs:collate_docs


### PR DESCRIPTION
Create a redundant archive for BCR upload; while we're at it, might as well optimize for higher compression

1. swapping gzip->xz shows reduction of 120k->71k which should slightly reduce impact to network congestion
2. one sanity-check adds the condition not blocking all submissions: the URL pattern used (default release archive) is not preferred.
    1. https://github.com/bazelbuild/bazel-central-registry/pull/2913
    2. detail in https://buildkite.com/bazel/bcr-presubmit/builds/8071#01926814-443a-490b-b670-35a4edb93d1e/147-156
    3. both failures are the same issue

