### PR TITLE
chore: DRY PACKAGE_ARCHES in toolchains for 7.2.2 TC later

### DIFF
--- a/arch/BUILD.bazel
+++ b/arch/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_synology//toolchains:deps.bzl", TOOLCHAINS = "TOOLCHAINS_SHORT_LC")
+load("@rules_synology//toolchains:deps.bzl", "PACKAGE_ARCHES", TOOLCHAINS = "TOOLCHAINS_SHORT_LC")
 
 # This BUILD file is simply a namespace separation so that we can show "//arch:denverton" as
 # something that makes sense to more Synology people than bog-standard Bazel people.
@@ -24,32 +24,6 @@ config_setting(
     name = "arm",
     values = {"cpu": "arm"},
 )
-
-# TODO: Move to DRY on config/
-# https://kb.synology.com/en-global/DSM/tutorial/What_kind_of_CPU_does_my_NAS_have
-PACKAGE_ARCHES = {
-    "denverton": {
-        "cpu": "x86",
-        "desc": "Intel Atom C3538 (x86 64bit)",
-    },
-    "geminilake": {
-        "alias": "GLK",
-        "cpu": "x86",
-        "desc": "Intel Celeron J4125 (x86 64bit)",
-    },
-    "r1000": {
-        "cpu": "x86",
-        "desc": "AMD Ryzen R1xxx (x86-64)",
-    },
-    "rtd1619b": {
-        "cpu": "arm64",
-        "desc": "Realtek RTD1619B (armv8-A)",
-    },
-    "v1000": {
-        "cpu": "x86",
-        "desc": "AMD Ryzen V1xxxB (x86-64)",
-    },
-}
 
 constraint_setting(
     # effectively an ENUM TYPE

--- a/toolchains/deps.bzl
+++ b/toolchains/deps.bzl
@@ -6,25 +6,58 @@ syno_toolchains = {
     # https://global.synologydownload.com/download/ToolChain/toolchain/7.2-72746/Marvell%20Armada%2037xx%20Linux%204.4.302/armada37xx-gcc1220_glibc236_armv8-GPL.txz
     # https://global.synologydownload.com/download/ToolChain/toolchain/7.1-42661/Marvell%20Armada%2037xx%20Linux%204.4.180/armada37xx-gcc850_glibc226_armv8-GPL.txz
     "armada37xx-gcc850_glibc226_armv8-GPL": {
+        "arch_desc": "Marvell Armada 37cc SoC (64bit)",  # Marvell 88F3710, 88F3720
         "common_name": "Armada37xx",
+        "cpu": "armv8",  # aarch64",
+        "dsm_version": "7.1-42661",
+        "kernel_version": "4.4.180",
         "prefix": "aarch64-unknown-linux-gnu",
         "sha256": "8188ffc98675e9185900e54550ea21962fa690974eb66cea3e5209591c000ff3",
         "subdir": "Marvell%20Armada%2037xx%20Linux%204.4.180",
+        "package_arch": "armada37xx",  # TODO: can we replace with a v["common_name"].lower() ?
     },
+    # https://global.synologydownload.com/download/ToolChain/toolchain/7.2-72746/Intel%20x86%20Linux%204.4.302%20%28Denverton%29/denverton-gcc1220_glibc236_x86_64-GPL.txz
     # https://global.synologydownload.com/download/ToolChain/toolchain/7.1-42661/Intel%20x86%20Linux%204.4.180%20%28Denverton%29/denverton-gcc850_glibc226_x86_64-GPL.txz
     "denverton-gcc850_glibc226_x86_64-GPL": {
+        "arch_desc": "Intel Atom C3538 (x86 64bit)",
         "common_name": "Denverton",
+        "cpu": "x86",  # "x86_64",
+        "dsm_version": "7.1-42661",
+        "kernel_version": "4.4.180",
         "prefix": "x86_64-pc-linux-gnu",
         "sha256": "06e77a4fc703d5dd593f1ca7580ef65eca7335329dfeed44ff80789394d8f23c",
         "subdir": "Intel%20x86%20Linux%204.4.180%20%28Denverton%29",
+        "package_arch": "denverton",
     },
     "geminilake-gcc850_glibc226_x86_64-GPL": {
+        "alias": "GLK",
+        "arch_desc": "Intel Celeron J4125 (x86 64bit)",
         "common_name": "GeminiLake",
+        "cpu": "x86",  # "x86_64",
+        "dsm_version": "7.1-42661",
+        "kernel_version": "4.4.180",
         "prefix": "x86_64-pc-linux-gnu",
         "sha256": "653789339d20262c31546371ab457d99faff88729e16cf91f3f7cced5606daf6",
         "subdir": "Intel%20x86%20Linux%204.4.180%20%28GeminiLake%29",
+        "package_arch": "geminilake",
     },
 }
+
+#    "r1000": {
+#        "cpu": "x86",
+#        "desc": "AMD Ryzen R1xxx (x86-64)",
+#    },
+#    "rtd1619b": {
+#        "cpu": "arm64",
+#        "desc": "Realtek RTD1619B (armv8-A)",
+#    },
+#    "v1000": {
+#        "cpu": "x86",
+#        "desc": "AMD Ryzen V1xxxB (x86-64)",
+#    },
+
+# https://kb.synology.com/en-global/DSM/tutorial/What_kind_of_CPU_does_my_NAS_have
+PACKAGE_ARCHES = {v["package_arch"]: {"cpu": v["cpu"], "desc": v["arch_desc"]} for k, v in syno_toolchains.items()}
 
 def deps():
     maybe(
@@ -42,6 +75,11 @@ def deps():
             name = arch,
             urls = [
                 "https://global.synologydownload.com/download/ToolChain/toolchain/7.1-42661/{}/{}.txz".format(parts["subdir"], arch),
+                "https://global.synologydownload.com/download/ToolChain/toolchain/{}/{}/{}.txz".format(
+                    parts["dsm_version"],
+                    parts["subdir"],
+                    arch,
+                ),
             ],
             strip_prefix = parts["prefix"],
             sha256 = parts["sha256"],


### PR DESCRIPTION
Package Arches mimics the SynoComm way of tracking; there's a few different parallel platform/arch arrays, and that's yet another.

I may chop this logic later, but right now, I'm de-duping or DRYing against the toolchains in advance of 7.2.2 toolchains and simplifying either into or out-of the `config/platforms.bzl` structure.  If there's chopping to come, let's do so after.