### PR TITLE
feat: include rich provider/dict for INFO file

### DIFF
--- a/synology/BUILD.bazel
+++ b/synology/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@com_github_aignas_rules_shellcheck//:def.bzl", "shellcheck_test")
+load(":info-file.bzl", "info_file")
+load(":infofile_test.bzl", "syno_test_suite")
 
 # I personally go back-and-forth about dozens of little files, or files here-doc'd into the build
 # logic.  Clearly, this is here-doc'd, but I can't promise consistency.
@@ -61,3 +63,8 @@ bzl_library(
         "@rules_pkg//pkg:bzl_srcs",
     ],
 )
+
+
+# Call a macro that defines targets that perform the tests at analysis time,
+# and that can be executed with "bazel test" to return the result.
+syno_test_suite(name = "myrules_test")

--- a/synology/info-file.bzl
+++ b/synology/info-file.bzl
@@ -79,6 +79,52 @@ Ref:
 * [Synology: INFO](https://help.synology.com/developer-guide/synology_package/INFO.html)
 """
 
+def valid_version(version):
+    """Pre-check that the given version is valid for Synology
+
+    Despite how standards are better if we all adhere to them -- pick one, don't make a new one --
+    I'm not checking due to any bias about formats: *SYNOLOGY* accepts only a specific format here.
+
+    synopkg will report an error if the version in an INFO file does not match the correct
+    format=[^\\d+(\\.\\d+){0,5}(-\\d+)?$] -- problem is, Bazel not supporting regex, the steps to check
+    this are more complex:
+
+    1. split across the "-": confirm either 1 or two results; fail otherwise
+    2. confirm that the second item of the "-" split is all numbers; fail otherwise
+    3. split the first  item of the "-" split by decimal
+    4. confirm that the decimal-split has 6 or fewer items; fail otherwise
+    5. confirmthat each of the results of the decimal-split are all just numbers
+    """
+    print("Pondering a version {}".format(version))
+
+    dash = version.split("-")
+
+    if len(dash) < 1 or len(dash) > 2:
+        fail("format of {} should match {}, one or two parts separated by hyphens, you have {} blocks".format(version, "[^\\d+(\\.\\d+){0,5}(-\\d+)?$]", len(dash)))
+    if len(dash) == 2 and not dash[1].isdigit():
+        fail("format of {} in {} should match {}, and {} should be numbers".format(dash[1], version, "[^\\d+(\\.\\d+){0,5}(-\\d+)?$]", dash[1]))
+
+    dots = dash[0].split(".", 7)
+    if len(dots) < 1 or len(dots) > 6:
+        fail("format of {} should match {}, 1-6 [0-9]+ between dots.  you have {} sets of numbers".format(version, "[^\\d+(\\.\\d+){0,5}(-\\d+)?$]", len(dots)))
+
+    for d in dots:
+        if not d.isdigit():
+            fail("format of {} should match {} (ie numbers sep by dots), your maj/min/patch block is non-digit {}".format(version, "[^\\d+(\\.\\d+){0,5}(-\\d+)?$]", d))
+
+    return True
+
+InfoFile = provider(fields = {
+    "package": "A unique name for the package: no namespacing,might clash with other definitions",
+    "version": "Package Version: a dotted-integer version with an optional hyphenated suffice number: 4.2.4-2668",
+    "os_min_ver": "Minimum DSM version that can install this package: a string without clear constraints: 'DSM 7.1.1-42962'",
+    "description": "A brief description of the Package: it may be multiline, but should be brief and concise",
+    "maintainer": "The name of the maintainer: we draw this from a Maintainer provider from the 'maintainer()' target",
+    "maintainer_url": "The email address of the maintainer: we draw this from a Maintainer provider from the 'maintainer()' target",
+    "arch": "Spec-separated text indicating comaptible architectures for this SPK: 'noarch x86_64'",
+    "thirdparty": "Boolean: is this SPK built outside of Synology corporation? (typically yes)",
+})
+
 def info_file_impl(ctx):
     # Build a manifest per some fairly predictable ordering: key:value pairs, but by wrapping as
     # parameters, we have the option of generating or deriving values.
@@ -127,7 +173,19 @@ def info_file_impl(ctx):
 
     ctx.actions.write(outfile, "\n".join(content), is_executable = False)
 
-    return [DefaultInfo(files = depset([outfile]))]
+    return [
+        DefaultInfo(files = depset([outfile])),
+        InfoFile(
+            package = ctx.attr.package_name,
+            version = ctx.attr.package_version,
+            os_min_ver = ctx.attr.os_min_ver,
+            description = ctx.attr.description,
+            maintainer = ctx.attr.maintainer[Maintainer].name,
+            maintainer_url = ctx.attr.maintainer[Maintainer].url,
+            arch = " ".join(ctx.attr.arch_strings),
+            thirdparty = "yes",
+        ),
+    ]
 
 info_file = rule(
     doc = doc,

--- a/synology/infofile_test.bzl
+++ b/synology/infofile_test.bzl
@@ -1,0 +1,44 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "analysistest")
+load("//synology:info-file.bzl", "info_file", "InfoFile")
+
+# ==== Check the InfoFile provider contents ====
+
+def _info_file_version_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    # Check a few versions for validity
+    asserts.equals(env, "some value", target_under_test[InfoFile].val)
+
+    # Done: remember to return end()
+    return analysistest.end(env)
+
+# This global variable acts as a handle for the unittest.  It needs to be a global since macros get
+# evaluated at loading time but the rule gets evaluated later, at analysis time. Since this is a
+# test rule, its name must end with "_test".
+info_file_contents_test = analysistest.make(_info_file_version_test_impl)
+
+# Macro to setup the test.
+def _test_info_file_contents():
+    # Rule under test: tagged 'manual' to avoid building on ':all', but remain available as a
+    # dependency of the test
+
+    info_file(name = "info_file_contents_subject", tags = ["manual"])
+
+    # Testing rule.
+    info_file_contents_test(name = "info_file_contents_test", target_under_test = ":info_file_contents_subject")
+
+
+def syno_test_suite(name):
+    # call all tests which depend on an instance of the rule under test
+#    _test_info_file_contents()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            # Testing rules inside _test_info_file_contents()
+            ":info_file_contents_test",
+        ],
+    )
+
+


### PR DESCRIPTION
This PR instantiates a provider in the return of the INFO file rules to allow dependents to use the attributes of the info file.

Additionally, a version-sanity-check is added to catch versions falling outside of Synology's near-SemVer version format.