### PR TITLE
fix: remove illegal include-v-in-tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,6 @@ jobs:
         id: release
         with:
           release-type: simple
-          include-v-in-tag: false
       -
         name: Clone Repo
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Fix an error in the release workflow:

```
Unexpected input(s) 'include-v-in-tag', valid inputs are ['token', 'release-type', 'path', 'target-branch', 'config-file', 'manifest-file', 'repo-url', 'github-api-url', 'github-graphql-url', 'fork', 'include-component-in-tag', 'proxy-server', 'skip-github-release', 'skip-github-pull-request', 'changelog-host']
```