### PR TITLE
feat: include rich provider/dict for INFO file

### DIFF
--- a/synology/BUILD.bazel
+++ b/synology/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@com_github_aignas_rules_shellcheck//:def.bzl", "shellcheck_test")
+load(":info-file.bzl", "info_file")
+load(":infofile_test.bzl", "syno_test_suite")
 
 # I personally go back-and-forth about dozens of little files, or files here-doc'd into the build
 # logic.  Clearly, this is here-doc'd, but I can't promise consistency.
@@ -61,3 +63,8 @@ bzl_library(
         "@rules_pkg//pkg:bzl_srcs",
     ],
 )
+
+
+# Call a macro that defines targets that perform the tests at analysis time,
+# and that can be executed with "bazel test" to return the result.
+syno_test_suite(name = "myrules_test")

--- a/synology/infofile_test.bzl
+++ b/synology/infofile_test.bzl
@@ -1,0 +1,93 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "analysistest")
+load("//synology:info-file.bzl", "info_file", "InfoFile","valid_version")
+load("//synology:maintainer.bzl", "maintainer")
+
+# ==== Check the InfoFile provider contents ====
+
+def _info_file_version_test_fail_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    asserts.false(env, valid_version(target_under_test[InfoFile].version))
+
+    # Done: remember to return end()
+    return analysistest.end(env)
+
+def _info_file_version_test_pass_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    asserts.true(env, valid_version(target_under_test[InfoFile].version))
+
+    # Done: remember to return end()
+    return analysistest.end(env)
+
+# This global variable acts as a handle for the unittest.  It needs to be a global since macros get
+# evaluated at loading time but the rule gets evaluated later, at analysis time. Since this is a
+# test rule, its name must end with "_test".
+info_file_version_pass_test = analysistest.make(_info_file_version_test_pass_impl)
+info_file_version_fail_test = analysistest.make(_info_file_version_test_fail_impl)  # "expect_failure = True" didn't work
+
+pass_versions = {
+    "P1": "1.2.3-1",
+    "P2": "1.2.3.4.5-1234567890",
+}
+fail_versions = {
+    "F1": "1.2.3-1rc14",
+    "F2": "1.2.3-1-6",
+    "F3": "1.2.3.4.5.6-1",
+}
+
+# Macro to setup the test.
+def _test_info_file_contents():
+    # Rule under test: tagged 'manual' to avoid building on ':all', but remain available as a
+    # dependency of the test
+
+    maintainer(
+        name = "mock_maint",
+        maintainer_name = "Allan Clark",
+        maintainer_url = "example.com/allan-is-the-king",
+    )
+
+    [info_file(
+        name = "info_file_contents_{}".format(k),
+        description = "test package info file",
+        maintainer = ":mock_maint",
+        os_min_ver = "7.1",
+        out = "INFO_{}".format(k),
+        package_name = "mock_package",
+        package_version = v,
+        tags = ["manual"],
+    ) for k,v in pass_versions.items()]
+
+    [info_file(
+        name = "info_file_contents_{}".format(k),
+        description = "test package info file",
+        maintainer = ":mock_maint",
+        os_min_ver = "7.1",
+        out = "INFO_{}".format(k),
+        package_name = "mock_package",
+        package_version = v,
+        tags = ["manual"],
+    ) for k,v in fail_versions.items()]
+
+    # Testing rule.
+    [info_file_version_pass_test(name = "info_file_version_{}_test".format(k), target_under_test = ":info_file_contents_{}".format(k)) for k in pass_versions.keys()]
+    [info_file_version_fail_test(name = "info_file_version_{}_test".format(k), target_under_test = ":info_file_contents_{}".format(k)) for k in fail_versions.keys()]
+
+
+def syno_test_suite(name):
+    # call all tests which depend on an instance of the rule under test
+    _test_info_file_contents()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            # Testing rules inside _test_info_file_contents()
+            ":info_file_version_{}_test".format(k) for k in pass_versions.keys()
+        ] + [
+            ":info_file_version_{}_test".format(k) for k in fail_versions.keys()
+        ],
+    )
+
+


### PR DESCRIPTION
This PR instantiates a provider in the return of the INFO file rules to allow dependents to use the attributes of the info file.

Additionally, a version-sanity-check is added to catch versions falling outside of Synology's near-SemVer version format.  Why?  Because I wasted some time building stuff that Synology refused due to vanity-format versions.  Really, do we need more than X.Y.Z-NNN ?  Do we need the 1.2.3.4.5-please-hammer-dont-hurt-em ?  It was my clear error for passing through this vanity crap without just cleaning it up and removing the upstream ego, so I won't make that error again.