### PR TITLE
chore: use setup-bazel for community-standard cache handling

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -43,7 +43,7 @@ jobs:
       -
         run: bazel build //...
       -
-        run: bazel test //... --test_output=errors --test_summary=detailed
+        run: bazel test //... --test_output=errors --test_summary=detailed --sandbox_debug
       -
         name: Build / Test examples to ensure functionality
         run: |

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -22,21 +22,30 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
+      #-
+      #  name: Date-Based Cache key
+      #  # get a key showing the current week (ISO: yyyyWww) allowing older caches to age-out/autoprune
+      #  id: week
+      #  run: echo "::set-output name=iso::$(date +'bazel-%YW%U')"
+      #-
+      #  uses: bazel-contrib/setup-bazel@0.8.5
+      #  with:
+      #    # Cache bazel downloads via bazelisk
+      #    bazelisk-cache: true
+      #    # Store build cache per week
+      #    disk-cache: ${{ steps.week.outputs.iso }}
+      #    # Share repository cache between workflows.
+      #    repository-cache: true
       - uses: actions/checkout@v4.2.2
-        # action runners have bazelisk: - uses: bazelbuild/setup-bazelisk@v2
         # https://github.com/bazelbuild/bazel/issues/11062
-      - run: mkdir -p "${TEST_TMPDIR}"
-      - run: env | sort
-      - name: Mount bazel cache  # Optional
-        uses: actions/cache@v4
-        with:
-          # needs to be an absolute path, not a variable; I've made it match TEST_TMPDIR above
-          path: /tmp/bazel
-          key: _bazel_runner
-      - run: bazel run //docs:collate_docs
-      - run: bazel build //...
-      - run: bazel test //...
-      - name: Build / Test examples to ensure functionality
+      -
+        run: bazel run //docs:collate_docs
+      -
+        run: bazel build //...
+      -
+        run: bazel test //... --test_output=errors --test_summary=detailed
+      -
+        name: Build / Test examples to ensure functionality
         run: |
             for d in $(find examples -name WORKSPACE -o -name MODULE.bazel -exec dirname {} \; ); do
             echo "::group::example: ${d}"
@@ -44,3 +53,5 @@ jobs:
             #(cd ${d} && test 1 -le $(bazel query 'kind("test", "//...")' 2> /dev/null | wc -l ) && echo "::group::test: ${d}" && bazel test //...);
             echo "::endgroup::"
             done
+      -
+        run: bazel shutdown

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       -
         name: Clone Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       -
         name: re-confirm a build
         run: bazel run //docs:collate_docs
@@ -33,6 +33,21 @@ jobs:
         id: release
         with:
           release-type: bazel
+      -
+        name: Date-Based Cache key
+        # get a key showing the current week (ISO: yyyyWww) allowing older caches to age-out/autoprune
+        id: week
+        run: echo "::set-output name=iso::$(date +'bazel-%YW%U')"
+      -
+        uses: bazel-contrib/setup-bazel@0.8.5
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          # Cache bazel downloads via bazelisk
+          bazelisk-cache: true
+          # Store build cache per week
+          disk-cache: ${{ steps.week.outputs.iso }}
+          # Share repository cache between workflows.
+          repository-cache: true
       -
         name: Clone Repo
         if: ${{ steps.release.outputs.release_created }}
@@ -77,3 +92,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # see https://github.com/marketplace/actions/deploy-mkdocs#example-usage
           # REQUIREMENTS: folder/requirements.txt
+      -
+        run: bazel shutdown


### PR DESCRIPTION
`setup-bazel` is where `setup-bazelisk` has moved (and from bazelbuild to bazel-contrib) and seems to have improved.  I lack the capability to coherently argue, and 'm confident that is `setup-bazel` does something wrong, the maintainer(s) will aggressively resolve.

I still use the build cache based on current (ISO) week so that older caches get stale.  GitHub will auto-prune these idle/stale caches, automatically pruning cached resources we no longer need.