### PR TITLE
fix: ensure "Upload Size-Optimized" gated on release creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,7 @@ jobs:
         env:
           TAG: ${{ steps.release.outputs.tag_name }}
           PREFIX: rules_synology-${{ steps.release.outputs.tag_name }}
+        if: ${{ steps.release.outputs.release_created }}
         run: gh release upload ${TAG} ${PREFIX}.tar.xz
       -
         name: Collate Docs


### PR DESCRIPTION
Builds such as https://github.com/chickenandpork/rules_synology/actions/runs/12048357991/job/33593493268 were failing on 'Upload Size-Optimized' having no `${TAG}`. Checking, it sees that build step in `workflows/release.yaml` was not correctly gated on actual release-creation, so I've added that here to ensure it doesn't run unless the release is created (implicitly: the other steps then run) 