### PR TITLE
chore: update pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 ---
 repos:
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.33.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
         args: [
@@ -18,7 +18,7 @@ repos:
         ]
         files: .*\.(yml|yaml)$
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.18
     hooks:
     - id: mdformat
       additional_dependencies:
@@ -36,17 +36,17 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.10.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.3
+    rev: 0.29.4
     hooks:
       - id: check-github-workflows
       - id: check-renovate
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v8.3.0
+    rev: v8.16.0
     hooks:
       - id: cspell
         # a local allowlist of dictionary words in .github/cspell.yaml.  This can get comical --


### PR DESCRIPTION
This PR both:
- does a basic update on the dependencies in pre-commit
    note that `executablebooks/mdformat-0.7.19` breaks formatting, but `0.7.18` is ok.
- churn the v0.0.4 release in #160, currently stuck waiting for missed completion signal on a build (so no retry workflow)