### PR TITLE
fix: correct prefix per change to google-release-please

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
-  "strip_prefix": "{REPO}-{VERSION}",
+  "strip_prefix": "{REPO}-{TAG}",
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.xz"
 }


### PR DESCRIPTION
```
Failed to publish entry for chickenandpork/rules_synology@v0.1.0 to the Bazel Central Registry.

Could not find MODULE.bazel in release archive at ./rules_synology-0.1.0/MODULE.bazel.
Is the strip prefix in source.template.json correct? (currently it's 'rules_synology-0.1.0')
```

- `{REPO}-{VERSION}` ==> `rules_synology-0.1.0`
- `{REPO}-{TAG}` ==> `rules_synology-v0.1.0`  <== winner winner chicken dinner
