### PR TITLE
Feat: integration tests don't need stubbed WORKSPACE

### DIFF
--- a/examples/cross-helloworld-no-go/WORKSPACE
+++ b/examples/cross-helloworld-no-go/WORKSPACE
@@ -1,1 +1,0 @@
-# required for gazelle; required for rules_bazel_integration_test

--- a/examples/cross-helloworld/WORKSPACE
+++ b/examples/cross-helloworld/WORKSPACE
@@ -1,1 +1,0 @@
-# required for gazelle; required for rules_bazel_integration_test

--- a/examples/example-docker-project/WORKSPACE
+++ b/examples/example-docker-project/WORKSPACE
@@ -1,1 +1,0 @@
-# required for gazelle; required for rules_bazel_integration_test

--- a/examples/example-kernelmod-spk/WORKSPACE
+++ b/examples/example-kernelmod-spk/WORKSPACE
@@ -1,1 +1,0 @@
-# required for gazelle; required for rules_bazel_integration_test

--- a/examples/example-server/WORKSPACE
+++ b/examples/example-server/WORKSPACE
@@ -1,1 +1,0 @@
-# required for gazelle; required for rules_bazel_integration_test


### PR DESCRIPTION
This PR will only land once:
- bazel-contrib/rules_bazel_integration_test#416 pr similar merges
- `MODULE.bazel` version-bumps the bazel_dep to include where that fix shipped

...so this won't work for a while, but will keep an eye on it.

## Testing

This was built and tested using a docker container generated form thin this repo:

```
docker run --rm -it \
    -v ~/src/rules_synology:/rules_synology \
    -v ~/src/rules_bazel_integration_test:/rules_bazel_integration_test \
    -w /rules_synology \
    ubuntu-x86:latest bash
```