### PR TITLE
fix: explicitly use rules_synology to mitigate anonymous rules and defaults

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,15 +1,15 @@
-# We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
-# For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
-bcr_test_module:
-  module_path: "examples/cross-helloworld-no-go"
-  matrix:
-    # ubuntu2004: the cross-env doesn't seem to work there
-    platform: ["ubuntu2204"]
-    bazel: [7.x]
-  tasks:
-    test_linux:
-      name: "Run linux crosstool tests"
-      bazel: ${{ bazel }}
-      platform: ${{ platform }}
-      test_targets:
-        - "//..."
+matrix:
+  platform:
+    - ubuntu2204
+    - macos
+  bazel: [7.x]
+tasks:
+  verify_targets:
+    name: Verify basic build targets
+    bazel: ${{ bazel }}
+    platform: ${{ platform }}
+    build_targets:
+      - '@rules_synology//...'
+      # Need a consistent "ignore" between .bazelignore, rules_bazel_integration_test, and other
+      # tools.  (NOTE: doing here out of caution to get BCR submit past un-repro-able issue)
+      - '-@rules_synology//examples/...'


### PR DESCRIPTION
Still guessing around the issue I cannot repro.  Shifting out of the `bcr_test_module` seems to allow me to use an explicit `@rules_synology//` in the build, which *could* allow the `@rules_synology` identifier to exist when it comes to the build.

Currently, the `8.0.0rc<whatever>` is blocked on `@rules_synology//models` not existing inside the `@rules_synology` module, and I cannot repro it whatever I do.

Current recommendation (Slack, https://bazelbuild.slack.com/archives/C014RARENH0/p1734045469423659)  is to tag with `presubmit-auto-run` in the BCR PR queue so that updates trigger re-runs.  That can help iterate new changes by proving that no new issue was introduced, but I'm frustrated trying to investigate the existing failure.  It seems to be removing the name of the rule from the `bazel_dep`, but no idea why.