### PR TITLE
fix: SPK needs username to be startable

### DIFF
--- a/examples/example-docker-project/spk/nginx/BUILD.bazel
+++ b/examples/example-docker-project/spk/nginx/BUILD.bazel
@@ -54,6 +54,7 @@ privilege_config(
     name = "priv",
     # run_as_root isn't working: Synology seems to throw a 313 or 319 error whenever I have any valid binaries in the run-as-root.  Need to optimize it over time.
     #run_as_root= [ "postinst", "preuninst"],
+    username = "sc-nginx",
 )
 
 resource_config(

--- a/examples/example-kernelmod-spk/spk/netfilter-mods/BUILD.bazel
+++ b/examples/example-kernelmod-spk/spk/netfilter-mods/BUILD.bazel
@@ -18,6 +18,7 @@ privilege_config(
     name = "priv",
     # run_as_root isn't working: Synology seems to throw a 313 or 319 error whenever I have any valid binaries in the run-as-root.  Need to optimize it over time.
     #run_as_root= [ "postinst", "preuninst"],
+    username = "sc-netfiltermods",
 )
 
 usr_local_linker(

--- a/examples/example-server/spk/exampleserver/BUILD.bazel
+++ b/examples/example-server/spk/exampleserver/BUILD.bazel
@@ -28,6 +28,7 @@ protocol_file(
 
 privilege_config(
     name = "priv",
+    username = "sc-exampleserver",
 )
 
 resource_config(

--- a/synology/info-file.bzl
+++ b/synology/info-file.bzl
@@ -125,7 +125,7 @@ InfoFile = provider(fields = {
     "description": "A brief description of the Package: it may be multiline, but should be brief and concise",
     "maintainer": "The name of the maintainer: we draw this from a Maintainer provider from the 'maintainer()' target",
     "maintainer_url": "The email address of the maintainer: we draw this from a Maintainer provider from the 'maintainer()' target",
-    "arch": "Spec-separated text indicating comaptible architectures for this SPK: 'noarch x86_64'",
+    "arch": "Space-separated text indicating compatible architectures for this SPK: 'noarch x86_64'",
     "ctl_stop": "Boolean: is there a start-stop-status script to allow the SPK to start or stop? (writes both startable and ctl_stop)",
     "thirdparty": "Boolean: is this SPK built outside of Synology corporation? (typically yes)",
 })

--- a/synology/privilege-configure.bzl
+++ b/synology/privilege-configure.bzl
@@ -22,6 +22,10 @@ def _privilege_config_impl(ctx):
         for s in ctx.attr.run_as_root:
             priv.append({"run-as": "root", "action": s})
         privilege_list.update({"ctrl-script": priv})
+    privilege_list.update({
+        "groupname": ctx.attr.groupname,
+        "username": ctx.attr.username,
+    })
 
     if ctx.outputs.out:
         outfile = ctx.outputs.out
@@ -52,7 +56,9 @@ privilege_config = rule(
     implementation = _privilege_config_impl,
     attrs = {
         "out": attr.output(mandatory = False),
-        "run_as_package": attr.string_list(mandatory = False),
-        "run_as_root": attr.string_list(mandatory = False),
+        "run_as_package": attr.string_list(doc = "list of apps/services that sound run-as the given username", mandatory = False),
+        "run_as_root": attr.string_list(doc = "list of apps/services that sound run-as root", mandatory = False),
+        "username": attr.string(doc = "app-specific posix/unix username under which the app/service runs", mandatory = True),
+        "groupname": attr.string(default = "rules_synology", doc = "posix/unix groupname in which the app-specific user is added", mandatory = False),
     },
 )


### PR DESCRIPTION
Lacking a username in the `privilege` config, the logs show entries such as:
```
2024/11/27 19:14:06 Failed to start package, pkg=[bazel-remote-cache] context=[{"action":"start","beta":false,"error":{"code":272,"description":"Failed to acquire startup worker","worker_msg":[]},"finished":true,"language":"","last_stage":"prepare_start","package":"bazel-remote-cache","pid":15124,"stage":"start_failed","status":"start_failed","status_code":272,"status_description":"failed to start on previous startup","success":false,"username":"","version":"2.4.4-1"}]
```

NB: the error code `272` seems to be related to permission problems in general.