### PR TITLE
chore: drop pinned rules_jvm_external now that stardoc-0.7.2 has landed

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,10 +9,9 @@ bazel_dep(name = "gazelle", version = "0.40.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.1.0")
 bazel_dep(name = "rules_go", version = "0.51.0")
-bazel_dep(name = "rules_jvm_external", version = "6.6")  # https://github.com/bazelbuild/stardoc/issues/257#issuecomment-2461324992
 bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "rules_shellcheck", version = "0.3.3", repo_name = "com_github_aignas_rules_shellcheck")
-bazel_dep(name = "stardoc", version = "0.7.2")  # remove redundant rules_jvm_external when 0.7.2 or greater
+bazel_dep(name = "stardoc", version = "0.7.2")
 
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 bazel_dep(name = "rules_bazel_integration_test", version = "0.29.0", dev_dependency = True)


### PR DESCRIPTION
#147 included (1913687f) a fix to pin `rules_jvm_external` to a version that didn't break, at least until the transitory dependency through `rules_stardoc` evolved to provide a non-broken version (in `rules_stardoc-0.7.2`).

Since we have updated `rules_stardoc` in #157 we can drop this band-aid.