### PR TITLE
fix: unblock release: meddle with bazelignore

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,9 @@ jobs:
         uses: actions/checkout@v4.2.2
       -
         name: re-confirm a build
-        run: bazel run //docs:collate_docs
+        run: |
+          echo 'examples' > .bazelignore  # remove '//docs'
+          bazel run //docs:collate_docs
 
   release:
     runs-on: ubuntu-latest
@@ -80,7 +82,9 @@ jobs:
       -
         name: Collate Docs
         if: ${{ steps.release.outputs.release_created }}
-        run: bazel run //docs:collate_docs
+        run: |
+          echo 'examples' > .bazelignore  # remove '//docs'
+          bazel run //docs:collate_docs
       -
         name: Deploy docs
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Unblock `google-release-please` failure:

Mitigate the failure in #200 build 90: (https://github.com/chickenandpork/rules_synology/actions/runs/12629893487/job/35188648651) by meddling with the `.bazelignore` just as we now do in the `bazel.yml` workflow.