### PR TITLE
feat: convert SVG images fallback from PNG

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,7 +1,15 @@
 # ignore the examples which are used to document suggested usage, validate this project,
 # and -- in future -- repro issues that may arise.  Per meteorcloudy, .bazelignore is transitory,
 # but its own format, not gitignore format
+bazel-bin
+bazel-cross-helloworld
+bazel-cross-helloworld-no-go
+bazel-example-aliased-dependency
+bazel-example-docker-project
+bazel-example-server
+bazel-out
+bazel-rules_synology
+bazel-testlogs
 docs
-bazel-*
 examples
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,7 @@ go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 
 # Include *direct* Go dependencies
-use_repo(go_deps, "com_github_disintegration_imaging")
+use_repo(go_deps, "com_github_disintegration_imaging", "com_github_srwiley_oksvg", "com_github_srwiley_rasterx", "org_golang_x_image")
 
 #
 # Toolchains

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,10 @@ go 1.23.4
 
 require github.com/disintegration/imaging v1.6.2
 
-require golang.org/x/image v0.27.0 // indirect
+require (
+	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
+	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
+	golang.org/x/image v0.27.0
+	golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 // indirect
+	golang.org/x/text v0.25.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c h1:km8GpoQut05eY3GiYWEedbTT0qnSxrCjsVbb7yKY1KE=
+github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c/go.mod h1:cNQ3dwVJtS5Hmnjxy6AgTPd0Inb3pW05ftPSX7NZO7Q=
+github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 h1:oDMiXaTMyBEuZMU53atpxqYsSB3U1CHkeAu2zr6wTeY=
+github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780/go.mod h1:mvWM0+15UqyrFKqdRjY6LuAVJR0HOVhJlEgZ5JWtSWU=
+github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef h1:Ch6Q+AZUxDBCVqdkI8FSpFyZDtCVBc2VmejdNrm5rRQ=
+github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef/go.mod h1:nXTWP6+gD5+LUJ8krVhhoeHjvHTutPxMYl5SvkcnJNE=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.27.0 h1:C8gA4oWU/tKkdCfYT6T2u4faJu3MeNS5O8UPWlPF61w=
 golang.org/x/image v0.27.0/go.mod h1:xbdrClrAUway1MUTEZDq9mz/UpRwYAkFFNUslZtcB+g=
+golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=
+golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
+golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=

--- a/synology/images.bzl
+++ b/synology/images.bzl
@@ -31,7 +31,7 @@ images = rule(
     attrs = {
         "sizes": attr.int_list(mandatory = False, default = [ 16, 24, 32, 48, 64, 72, 90, 120, 256 ], doc = "sizes to convert: use a list of ints, each of which is a desired size of a square bounding box."),
         "src": attr.label(allow_single_file = True,mandatory = True, doc = "Initial source image to convert to various sizes."),
-        "images_template": attr.string(doc = "template for output files: use a string with a single {} that will be replaced with the size.  The template should end with a suffix that determines the resulting format: .png, .jpg, .PNG, etc.  Note that Synology SPK packaging requires files of the form PACKAGE_ICON_<size>.PNG so changing this should ential converting the result back however desired for the payload of the SPK.", mandatory=False),
+        "images_template": attr.string(doc = "template for output files: use a string with a single {} that will be replaced with the size.  The template should end with a suffix that determines the resulting format: .png, .jpg, .PNG, etc.  Note that Synology SPK packaging requires files of the form PACKAGE_ICON_<size>.PNG so changing this should entail converting the result back however desired for the payload of the SPK.", mandatory=False),
         "_resize": attr.label(
             default=Label("//tools:resize"),
             allow_single_file = True,

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -24,7 +24,12 @@ go_library(
     ],
     importpath = "github.com/chickenandpork/rules_synology/tools",
     visibility = ["//visibility:private"],
-    deps = ["@com_github_disintegration_imaging//:imaging"],
+    deps = [
+        "@com_github_disintegration_imaging//:imaging",
+        "@com_github_srwiley_oksvg//:oksvg",
+        "@com_github_srwiley_rasterx//:rasterx",
+        "@org_golang_x_image//draw",
+    ],
 )
 
 # TL;DR: needed for `bazel test //examples:all_integration_tests`

--- a/tools/resize.go
+++ b/tools/resize.go
@@ -2,7 +2,13 @@ package main
 
 import (
 	"errors"
+	"image"
+	"image/png"
+	"os"
+
 	"github.com/disintegration/imaging"
+	"github.com/srwiley/oksvg"
+	"github.com/srwiley/rasterx"
 )
 
 func ResizeImageFromFile(imageFile string, outFile string, newHeight int) error {
@@ -20,4 +26,31 @@ func ResizeImageFromFile(imageFile string, outFile string, newHeight int) error 
 	err = imaging.Save(nrgba, outFile)
 
 	return err
+}
+
+func ResizeSVGImageFromFile(imageFile string, outFile string, newHeight int) error {
+	f, err := os.Open(imageFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	icon, err := oksvg.ReadIconStream(f)
+	if err != nil {
+		return err
+	}
+
+	newWidth := int(float64(newHeight) * icon.ViewBox.W / icon.ViewBox.H)
+
+	icon.SetTarget(0, 0, float64(newWidth), float64(newHeight))
+	nrgba := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
+	icon.Draw(rasterx.NewDasher(newWidth, newHeight, rasterx.NewScannerGV(newWidth, newHeight, nrgba, nrgba.Bounds())), 1.0)
+
+	out, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	return png.Encode(out, nrgba)
 }


### PR DESCRIPTION
In some example work for SPKs, I ran into the need to convert SVG files as icons.  The existing libraries I used didn't do that.

I've extended the conversion to try PNG, but failing that, fallback to SVG conversion.  It's too different systems, but I hope to refactor and simplify eventually.  For now, it works.