### PR TITLE
feat: provide systemd-user-unit

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -9,6 +9,7 @@ load("//synology:privilege-configure.bzl", _privilege_config = "privilege_config
 load("//synology:resource-configure.bzl", _resource_config = "resource_config")
 load("//synology:unittests.bzl", _confirm_binary_matches_platform = "confirm_binary_matches_platform", _spk_component = "spk_component")
 load("//synology:usr-local-linker.bzl", _usr_local_linker = "usr_local_linker")
+load("//synology:systemd-user-unit.bzl", _systemd_user_unit = "systemd_user_unit")
 
 SPK_REQUIRED_SCRIPTS = ["preinst", "postinst", "preuninst", "postuninst", "preupgrade", "postupgrade"]
 
@@ -27,4 +28,5 @@ protocol_file = _protocol_file
 resource_config = _resource_config
 service_config = _service_config
 spk_component = _spk_component
+systemd_user_unit = _systemd_user_unit
 usr_local_linker = _usr_local_linker

--- a/synology/resource-configure.bzl
+++ b/synology/resource-configure.bzl
@@ -6,6 +6,7 @@
 
 load("//synology:docker-project.bzl", "DockerProject")
 load("//synology:port-service-configure.bzl", "PortConfigInfo")
+load("//synology:systemd-user-unit.bzl", "SystemdUserUnit")
 load("//synology:usr-local-linker.bzl", "UsrLocalLinker")
 
 def _resource_config_impl(ctx):
@@ -21,6 +22,8 @@ def _resource_config_impl(ctx):
             resource_list["docker-project"] = r[DockerProject].struct
         elif PortConfigInfo in r and r[PortConfigInfo]:
             resource_list["port-config"] = r[PortConfigInfo].struct
+        elif SystemdUserUnit in r and r[SystemdUserUnit]:
+            resource_list["systemd-user-unit"] = r[SystemdUserUnit]
         elif UsrLocalLinker in r and r[UsrLocalLinker]:
             if "usr-local-linker" not in resource_list:
                 resource_list["usr-local-linker"] = r[UsrLocalLinker]
@@ -32,9 +35,9 @@ def _resource_config_impl(ctx):
                 })
         else:
             print(
-                "WARNING: no providers generated from docker_project(), port_config()," +
-                " usr_local_linker() were found.  May be an error in resource_config(name = {},...)"
-                    .format(ctx.attr.name),
+                "WARNING: no providers generated from docker_project(), port_config(), " +
+                "systemd_user_unit(), nor usr_local_linker() were found.  May be an error in " +
+                "resource_config(name = {},...)".format(ctx.attr.name),
             )
 
     # appending "" element and joining results in a finishing blank line which has no effect on JSON

--- a/synology/systemd-user-unit.bzl
+++ b/synology/systemd-user-unit.bzl
@@ -1,0 +1,95 @@
+# This set of functions allows registration of a systemd unit config (USER, not System, yet).
+#
+# With this code, a file at conf/systemd/pkguser-<name> is registered for copy to
+# home/.config/systemd/user/ during postinst, and removed in postuninst stages.  Per the document
+# at ref (using 7.2.2 version for this initial work), the package should then use
+# `synosystemctl start` and `synosystemctl stop` to control the service inside scripts (which should
+# include the SSS script).
+#
+# The config this creates is a trivial block in the resource file, triggering Synology install
+# routines to look in a conventional/assumed location:
+#
+# inside the resource file:
+#
+# # resource file
+# {
+#   ...
+#   "systemd-user-unit": {}
+#   ...
+# }
+#
+# Documentation doesn't indicate how the assumed file is named, but it seems to be a single file at
+# conf/systemd/pkguser-<name>.  It *seems* that the install prociess at postinst stage will copy
+# one (or more?) units to this home/.config/systemd/user/ path.  Likely if multiple units exist,
+# they will be copied to that path, avoiding name-clash within the package by requiring uniqueness
+# in the wrapping tar archive, and avoiding name-clash on the running Synology by using the
+# username as a namespace.
+#
+# The resulting file is a standard system unit config from what I can see; this portion of the unit
+# simply logs that the installer needs to do the copy/removal at the proper stages.  The installer
+# doesn't run the start/stop automatically, it seems running those in a SSS file is conventional
+# means of activating.
+
+doc = """## Configure a /usr/local Linker
+
+The Systemd User Unit is a [Worker](glossary.md#worker) that triggers the install process to make
+available the systemd unit(s) in `conf/systemd/pkguser-<name>` into `home/.config/systemd/user/`
+during postinst, removing during postuninst.  The package should then use `synosystemctl start` and
+`synosystemctl stop` to control the service inside scripts (which should include the SSS script).
+
+### Example
+This will cause a system user unit module to be copied from `conf/systemd/pkguser-awesomesauce` to
+`home/.config/systemd/user/` so that the postinst step can trigger `synosystemctl start` in an SSS
+script run during `postinst` stage (including the enclosing wrappers for clarity):
+
+```
+load("@//:defs.bzl", "resource_config", "systemd_user_unit")
+
+systemd_user_unit(
+    name = "systemd-awesome",
+)
+...
+resource_config(
+    name = "rez",
+    resources = [ ... ":systemd-awesome" ],
+)
+
+pkg_files(
+    name = "conf",
+    srcs = [ ...  ":rez" ],
+    prefix = "conf",
+)
+
+pkg_tar(
+    name = "awesomesauce",
+    srcs = [ ...  ":conf" ],
+    ],
+    extension = "tar",
+    package_file_name = "awesomesauce.spk",
+)
+
+```
+
+References:
+
+* [Synology: Systemd User Unit](https://help.synology.com/developer-guide/resource_acquisition/systemd_user_unit.html)
+"""
+
+SystemdUserUnit = provider(
+    doc = """SystemdUserUnit triggers opinionated packaging and behavior uing uinstall for systemd user units.""",
+    fields = {
+        #"unit": "Future intentions to carry the names of user-unit files, generate a pkg_files or pkg_tar of the unit file remapped to proper path",
+    },  # type detection only
+)
+
+def _systemd_user_unit_impl(ctx):
+    return [
+        DefaultInfo(),  # stub
+        SystemdUserUnit(),  # provider signature used only
+    ]
+
+systemd_user_unit = rule(
+    doc = doc,
+    implementation = _systemd_user_unit_impl,
+    attrs = { },
+)


### PR DESCRIPTION
This PR brings in the basic ability to say "there is a system unit".  There's no additional work from there -- you'll still need to cause the system unit file to be present in `conf/systemd/pkguser-<name>.service` -- but there's the opportunity to make that simpler for the user down the road.