### PR TITLE
feat: single-image conversion

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -1,7 +1,7 @@
 # Formats guided by https://global.download.synology.com/download/Document/Software/DeveloperGuide/Os/DSM/All/enu/DSM_Developer_Guide_7_enu.pdf
 
 load("//synology:docker-project.bzl", _docker_compose = "docker_compose", _docker_project = "docker_project")
-load("//synology:images.bzl", _images = "images")
+load("//synology:images.bzl", _image = "image", _images = "images")
 load("//synology:info-file.bzl", _info_file = "info_file")
 load("//synology:maintainer.bzl", "Maintainer", _maintainer = "maintainer")
 load("//synology:port-service-configure.bzl", _protocol_file = "protocol_file", _service_config = "service_config")
@@ -20,6 +20,7 @@ confirm_binary_matches_platform = _confirm_binary_matches_platform
 #docker_compose = _docker_compose
 docker_compose = _docker_compose
 docker_project = _docker_project
+image = _image
 images = _images
 info_file = _info_file
 maintainer = _maintainer

--- a/synology/images.bzl
+++ b/synology/images.bzl
@@ -1,3 +1,42 @@
+def _image_impl(ctx):  # SINGLE image
+    target_name = ctx.attr.image or "PACKAGE_ICON.PNG"
+    target = ctx.actions.declare_file(target_name)
+    ctx.actions.run(
+        outputs = [target],
+        inputs = [ctx.file.src],
+        arguments = [
+            "-src={}".format(ctx.file.src.path),
+            "-size={}".format(ctx.attr.size),
+            "-dest={}".format(target.path),
+            "-verbose" if ctx.attr.verbose else "",
+        ],
+        executable = ctx.executable._resize,
+        mnemonic = "Resizing",
+    )
+
+    return [DefaultInfo(
+        files=depset([target]),
+        runfiles= ctx.attr._resize[DefaultInfo].default_runfiles,
+    )]
+
+
+image = rule(
+    doc = """Create a single resized image from the src image.""",
+    implementation = _image_impl,
+    attrs = {
+        "size": attr.int(mandatory = False, default = 256, doc = "size (length of square bounding box) to convert src to."),
+        "src": attr.label(allow_single_file = True,mandatory = True, doc = "Initial source image to convert to desired size."),
+        "image": attr.string(doc = "name of target image file.  The name should end with a suffix that determines the resulting format: .png, .jpg, .PNG, etc.", mandatory=False),
+        "_resize": attr.label(
+            default=Label("//tools:resize"),
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+        "verbose": attr.bool(default=False, doc = "Verbosity can enable some debug messages from //tools:resize that can help resolve errors."),
+    }
+)
+
 def _images_impl(ctx):
     out_collector = []
     images_template = ctx.attr.images_template or "PACKAGE_ICON_{}.PNG"
@@ -41,4 +80,3 @@ images = rule(
         "verbose": attr.bool(default=False, doc = "Verbosity can enable some debug messages from //tools:resize that can help resolve errors."),
     }
 )
-


### PR DESCRIPTION
In creating an SPK with a UI, I needed a variable of the image as an icon; I didn't have a way to pull that from the `images()` function, so I've just made a one-off.  I can merge these for convenience, but right now, this gets me where I need to be.