### PR TITLE
fix: correct portconfig path

### DIFF
--- a/synology/port-service-configure.bzl
+++ b/synology/port-service-configure.bzl
@@ -84,7 +84,7 @@ def _protocol_file_impl(ctx):
         ),
         PortConfigInfo(
             protocol_file = protocol_filename,
-            struct = {"protocol-file": protocol_filename},
+            struct = {"protocol-file": "conf/{}".format(protocol_filename)},
         ),
     ]
 


### PR DESCRIPTION
A minor change in the assumed path of a port config