### PR TITLE
fix: ensure RenovateBot manages go.mod everywhere

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,10 +21,20 @@
   "packageRules": [
     {
       "enabled": true,
+      "groupName": "Go module updates",
+      "matchFiles": [
+        "**/go.mod"
+      ],
+      "matchManagers": [
+        "gomod"
+      ]
+    },
+    {
+      "enabled": true,
+      "groupName": "Bazel module updates",
       "matchManagers": [
         "bazel",
-        "bazel-module",
-        "gomod"
+        "bazel-module"
       ]
     },
     {


### PR DESCRIPTION
So far, we've been happily accepting updates to dependencies, but the examples haven't been reviewed for updates, only the base/root/workspace directory.

This PR expands the file pattern to allow `go.mod` to be reviewed and maintained everywhere.