### PR TITLE
fix: ensure RenovateBot manages MODULE.bazel everywhere

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,9 @@
     {
       "enabled": true,
       "groupName": "Bazel module updates",
+      "matchFileNames": [
+        "**/MODULE.bazel"
+      ],
       "matchManagers": [
         "bazel",
         "bazel-module"


### PR DESCRIPTION
So far, we've been happily accepting updates to dependencies, but the examples haven't been reviewed for updates, only the base/root/workspace directory.

Expanding #265, this PR expands the file pattern to allow `MODULE.bazel` to be reviewed and maintained everywhere.