### PR TITLE
fix: detect when dependencies are migration-mitigated

### DIFF
--- a/.github/workflows/confirm-migrations.yaml
+++ b/.github/workflows/confirm-migrations.yaml
@@ -1,0 +1,30 @@
+name: Confirm Migrations
+
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  # typically used for bazel internal testing: changes outputRoot, sets idletimeout to ~15s
+  TEST_TMPDIR: /tmp/bazel
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+  push:
+
+jobs:
+  build:
+    name: Confirm Zero Outstanding Migrations
+    concurrency:
+       # trivial group in this shallow matrix but autocatches expansion
+       cancel-in-progress: true
+       group: ${{ github.ref }}-${{ github.workflow }}-${{ matrix.os }}-build
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/checkout@v5.0.0
+        # https://github.com/bazelbuild/bazel/issues/11062
+      -
+        run: bazelisk --migration build //...
+      # If migrations ultimately pass due to dependencies updating, I'll be able to merge this

--- a/.github/workflows/confirm-migrations.yaml
+++ b/.github/workflows/confirm-migrations.yaml
@@ -26,5 +26,5 @@ jobs:
         uses: actions/checkout@v5.0.0
         # https://github.com/bazelbuild/bazel/issues/11062
       -
-        run: bazelisk --migration build //...
+        run: bazelisk --migrate build //...
       # If migrations ultimately pass due to dependencies updating, I'll be able to merge this


### PR DESCRIPTION
As noted in #252 Bazelisk detects some migration issues with the release; unfortunately, these tend to be in the dependencies of the project: the things we need are unclean, it's not us.

When they do pas, this PR can auto-merge.  Until then, it's gonna keep re-testing for months.