### PR TITLE
feat: trivial initial generated SSS

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -8,9 +8,10 @@ load("//synology:maintainer.bzl", "Maintainer", _maintainer = "maintainer")
 load("//synology:port-service-configure.bzl", _protocol_file = "protocol_file", _service_config = "service_config")
 load("//synology:privilege-configure.bzl", _privilege_config = "privilege_config")
 load("//synology:resource-configure.bzl", _resource_config = "resource_config")
+load("//synology:start-stop-template.bzl", _simple_start_stop_script = "simple_start_stop_script")
+load("//synology:systemd-user-unit.bzl", _systemd_user_unit = "systemd_user_unit")
 load("//synology:unittests.bzl", _confirm_binary_matches_platform = "confirm_binary_matches_platform", _spk_component = "spk_component")
 load("//synology:usr-local-linker.bzl", _usr_local_linker = "usr_local_linker")
-load("//synology:systemd-user-unit.bzl", _systemd_user_unit = "systemd_user_unit")
 
 SPK_REQUIRED_SCRIPTS = ["preinst", "postinst", "preuninst", "postuninst", "preupgrade", "postupgrade"]
 
@@ -31,5 +32,6 @@ protocol_file = _protocol_file
 resource_config = _resource_config
 service_config = _service_config
 spk_component = _spk_component
+simple_start_stop_script = _simple_start_stop_script
 systemd_user_unit = _systemd_user_unit
 usr_local_linker = _usr_local_linker

--- a/synology/start-stop-template.bzl
+++ b/synology/start-stop-template.bzl
@@ -1,0 +1,70 @@
+# I find myself writing this basic SSS script over and over; this should be templated, with some
+# basic flexibility, split to other perhaps if this stretches the single function too far.
+
+load("//synology:info-file.bzl", "InfoFile")
+load("//synology:docker-project.bzl", "DockerProject")
+
+
+SSSInfo = provider(
+    fields = {
+        "bogus": "no fields yet..."
+    },
+)
+
+def _simple_start_stop_script_impl(ctx):
+    outfile = ctx.outputs.outscript or ctx.actions.declare_file("start-stop-status")
+    docker_projects = []
+    package_name = ""  # set by giving an "info_file" as deps
+
+    for d in ctx.attr.deps or []:
+        #typeswitch on provider
+        if DockerProject in d:
+            for name,path in d[DockerProject].projects.items():
+                docker_projects.append(path)
+        elif InfoFile in d:
+            package_name = d[InfoFile].package
+        else:
+            print("Dependency {} skipped: no recognized providers".format(d.label))
+
+
+    compose_up_command = ""
+    compose_down_command = ""
+
+    # this needs to have both package name and docker_projects defined
+    if len(docker_projects) and not package_name:
+        print("DockerProject dependency needs an info_file() dep to provide package_name")
+    elif len(docker_projects):
+        # example:  docker-compose -f /var/packages/<package>/target/<path>/compose.yaml up
+        compose_down_command = "for p in {}; do docker-compose -f /var/packages/{package_name}/target/${{p}}/compose.yaml down; done".format(" ".join(docker_projects), package_name = package_name)
+        compose_up_command = "for p in {}; do docker-compose -p {package_name} -f /var/packages/{package_name}/target/${{p}}/compose.yaml up --detach; done".format(" ".join(docker_projects), package_name = package_name)
+
+        # example: docker-compose ls --format json | jq -c --arg PN "talospxe" '.[]|select(.Name==$PN)|{Name, Status}'
+        print("package_name is", package_name)
+        compose_status_command = "docker-compose ls --format json | jq -c --arg PN {} '.[]|select(.Name==$PN)|{{Name, Status}}'".format(package_name)
+
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = outfile,
+        substitutions = {
+            "COMPOSE_DOWN": compose_down_command,
+            "COMPOSE_STATUS": compose_status_command,
+            "COMPOSE_UP": compose_up_command,
+        },
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(files = depset([outfile])),
+        SSSInfo(bogus = "bogus"),
+    ]
+
+simple_start_stop_script = rule(
+    doc = "This function provides a method of programmatically creatng the start/stop service script.  It may become much more as the ruleset evolves.",
+    implementation = _simple_start_stop_script_impl,
+    attrs = {
+        "_template": attr.label(allow_single_file = True, default = "start_stop_template_simple.tpl"),
+        "deps": attr.label_list(mandatory = False),   # providers = [InfoFile, DockerProject]
+        "outscript": attr.output(),
+    },
+)
+

--- a/synology/start_stop_template_simple.tpl
+++ b/synology/start_stop_template_simple.tpl
@@ -1,0 +1,16 @@
+#!/bin/sh
+# This is rules_synology/synology/start_stop_template_simple.tpl
+
+case "$1" in
+    start)
+        COMPOSE_UP
+        ;;
+    stop)
+        COMPOSE_DOWN
+        ;;
+    status)
+        COMPOSE_STATUS
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
This PR brings in an optional generated SSS.  It's not overly amazing yet, but the intent is to take a few objects (such as the INFO) and generate the SSS from the information provided.

This example generates a `docker-compose {start|stop|status}` so that starting the container (which doesn't seem to be automatic) can be done trivially.

Follow-on would be the pkgctl-{name}.service that triggers this SSS on boot and/or install.  I think that would give us the automation that is implied in the DSM7 documentation.